### PR TITLE
Remove dynamixel_urdf dependencies

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -21,9 +21,6 @@ rosdep update
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws
 ln -sf ${CI_SOURCE_PATH} src/${REPOSITORY_NAME}
-wstool init src
-wstool set dynamixel_urdf https://github.com/jsk-enshu/dynamixel_urdf --git -t src -y
-wstool update -t src
 rosdep install --from-paths src -y --ignore-src --rosdistro ${ROS_DISTRO}
 source /opt/ros/${ROS_DISTRO}/setup.bash
 env | grep ROS

--- a/dxl_armed_turtlebot/package.xml
+++ b/dxl_armed_turtlebot/package.xml
@@ -8,7 +8,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>dynamixel_urdf</build_depend>
   <build_depend>dynamixel_7dof_arm</build_depend>
   <build_depend>turtleboteus</build_depend>
   <build_depend>roseus</build_depend>
@@ -18,7 +17,6 @@
 
   <run_depend>controller_manager</run_depend>
   <run_depend>depthimage_to_laserscan</run_depend>
-  <run_depend>dynamixel_urdf</run_depend>
   <run_depend>dynamixel_7dof_arm</run_depend>
   <run_depend>dynamixel_motor</run_depend>
   <run_depend>gazebo_plugins</run_depend>


### PR DESCRIPTION
If we do not need `dynamixel_urdf` anymore we can remove it from the dependencies too.

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
dxl_armed_turtlebot: Cannot locate rosdep definition for [dynamixel_urdf]
```

Maybe change the README to use `git clone` instead of `wstool` ?